### PR TITLE
Add Rails 6 support to the version checker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.6.5
 script:
   # ---if you written test cases then write commands here to run
 

--- a/lib/country_state_select.rb
+++ b/lib/country_state_select.rb
@@ -64,6 +64,8 @@ module CountryStateSelect
 end
 
 case ::Rails.version.to_s
+  when /^6/
+    require 'country_state_select/engine'
   when /^5/
     require 'country_state_select/engine'
   when /^4/

--- a/lib/country_state_select/version.rb
+++ b/lib/country_state_select/version.rb
@@ -1,3 +1,3 @@
 module CountryStateSelect
-  VERSION = "3.0.3"
+  VERSION = "3.0.4"
 end

--- a/spec/country_state_select_spec.rb
+++ b/spec/country_state_select_spec.rb
@@ -25,7 +25,6 @@ describe CountryStateSelect do
     let(:exceptions) {  [us, sm]  }
 
     it 'does include the United States ordinarily' do
-      binding.pry
       expect(CountryStateSelect.countries_except([])).to include(us)
     end
 


### PR DESCRIPTION
- [x] Added Rails6 support to the version checker.
- [x] Bumped the gem version to `3.0.4`
- [x] Testing against Ruby 2.6.5
- [x] Removed debug code from the tests